### PR TITLE
Dev userdata

### DIFF
--- a/cloud_scheduler
+++ b/cloud_scheduler
@@ -30,6 +30,7 @@ import string
 import getopt
 import signal
 import logging
+import urllib2
 import threading
 import traceback
 import ConfigParser
@@ -716,6 +717,38 @@ class Scheduler(threading.Thread):
             local_modifications += start_requirement
 
         customizations.append((local_modifications, '/etc/condor/condor_config.local.modifications'))
+        
+        # Read and add admin's user data scripts which must be local files
+        if config.default_VMUserData:
+            for userdata in config.default_VMUserData:
+                try:
+                    file_content = open(userdata).read()
+                    basename = os.path.basename(userdata)
+                    filename = "admin_userdata_%s" % (basename) 
+                    destination = "/etc/condor/%s" % (filename)
+                    executable = False
+                    if re.match('^#!/.*', file_content):
+                        executable = True
+                    customizations.append((file_content, destination, executable))            
+                except:
+                    log.error('Error reading %s' % (userdata))
+        
+                    
+        # Read and add user's user data scripts which must be accessible via http 
+        if job.user_data:
+            for userdata in job.user_data:
+                try:
+                    file_content = urllib2.urlopen(userdata).read()
+                    basename = os.path.basename(userdata)
+                    filename = "user_userdata_%s" % (basename) 
+                    destination = "/etc/condor/%s" % (filename)
+                    executable = False
+                    if re.match('^#!/.*', file_content):
+                        executable = True
+                    customizations.append((file_content, destination, executable)) 
+                except:
+                    log.error('Error reading %s' % (userdata))               
+        
         log.verbose("Finished customizations for job '%s'" % job.id)
         for resource in good_resources:
             # Print details of the resource selected

--- a/cloud_scheduler.conf
+++ b/cloud_scheduler.conf
@@ -591,6 +591,12 @@ condor_collector_url: http://localhost:9618
 #   the default is False (use the x509userproxy to boot VMs as well)
 #default_VMProxyNonBoot: False
 
+# default_VMUserData specifies the EC2 user data which will be passed on to 
+#   metadata service and eventually into the virtual machine.
+#
+#   there is no default
+#default_VMUserData: /your/user_data
+
 [logging]
 
 # log_level specifies how much information from Cloud Scheduler to log. 

--- a/cloudscheduler/config.py
+++ b/cloudscheduler/config.py
@@ -102,6 +102,7 @@ default_VMStorage= 0
 default_VMInstanceType= ""
 default_VMMaximumPrice= 0
 default_VMProxyNonBoot = False
+default_VMUserData = []
 
 log_level = "INFO"
 log_location = None
@@ -202,6 +203,7 @@ def setup(path=None):
     global default_VMInstanceType
     global default_VMMaximumPrice
     global default_VMProxyNonBoot
+    global default_VMUserData
 
     global log_level
     global log_location
@@ -769,6 +771,9 @@ def setup(path=None):
         except ValueError:
             print "Configuration file problem: default_VMProxyNonBoot must be a" \
                   " Boolean value."
+
+    if config_file.has_option("job", "default_VMUserData"):
+        default_VMUserData = config_file.get("job", "default_VMUserData").replace(' ', '').strip('"').split(',')
 
     # Derived options
     if condor_host_on_vm:

--- a/cloudscheduler/job_management.py
+++ b/cloudscheduler/job_management.py
@@ -93,7 +93,7 @@ class Job:
              VMProxyNonBoot=config.default_VMProxyNonBoot,
              VMImageProxyFile=None, VMTypeLimit=-1, VMImageID=None,
              VMInstanceTypeIBM=None, VMLocation=None, VMKeyName=None,
-             VMSecurityGroup="", **kwargs):
+             VMSecurityGroup="", VMUserData="", **kwargs):
         """
      Parameters:
      GlobalJobID  - (str) The ID of the job (via condor). Functions as name.
@@ -112,6 +112,7 @@ class Job:
      VMHighPriority - (int) Indicates a High priority job / VM (default = 0)
      VMInstanceType - (str) The EC2 instance type of the VM requested
      VMMaximumPrice - (str) The maximum price in cents per hour for a VM (EC2 Only)
+     VMUserData - (str) The EC2 user data passed into VM
      CSMyProxyCredsName - (str) The name of the credentials to retreive from the myproxy server
      CSMyProxyServer - (str) The hostname of the myproxy server to retreive user creds from
      CSMyProxyServerPort - (str) The port of the myproxy server to retreive user creds from
@@ -173,6 +174,7 @@ class Job:
         self.location = VMLocation
         self.key_name = VMKeyName
         self.req_security_group = splitnstrip(',', VMSecurityGroup)
+        self.user_data = splitnstrip(',', VMUserData)
 
         # Set the new job's status
         if self.job_status == 2:

--- a/cloudscheduler/nimbus_xml.py
+++ b/cloudscheduler/nimbus_xml.py
@@ -270,6 +270,15 @@ def ws_optional(custom_tasks):
         filewrite.appendChild(pathOnVM_el)
         pathOnVM = doc.createTextNode(task[1])
         pathOnVM_el.appendChild(pathOnVM)
+        
+        executable_el = doc.createElement("executable")
+        filewrite.appendChild(executable_el)
+        executable = 'False'
+        if len(task) > 2:
+            if task[2] == True:
+                executable = 'True'
+        executable_tn = doc.createTextNode(executable)
+        executable_el.appendChild(executable_tn)
 
     return doc.toxml(encoding="utf-8")
 

--- a/scripts/ec2contexthelper/contexthelper
+++ b/scripts/ec2contexthelper/contexthelper
@@ -9,14 +9,18 @@
 #    <filewrite>
 #        <content>These are the contents</content>
 #        <pathOnVM>/tmp/custom</pathOnVM>
+#        <executable>False</executable>
 #    </filewrite>
 #    <filewrite>
 #        <content>These are the contents</content>
 #        <pathOnVM>/tmp/custom0</pathOnVM>
+#        <executable>True</executable>
 #    </filewrite>
 #</OptionalParameters>
 
+import os
 import sys
+import stat
 from xml.dom import minidom
 import urllib2
 
@@ -33,11 +37,18 @@ user_data = minidom.parseString(user_data_xml)
 for file in user_data.getElementsByTagName("filewrite"):
     path = file.getElementsByTagName("pathOnVM")[0].firstChild.nodeValue
     content = file.getElementsByTagName("content")[0].firstChild.nodeValue
+    executable = file.getElementsByTagName("executable")[0].firstChild.nodeValue
 
     try:
         f = open(path, "w")
         f.write(content)
         f.close()
+        if executable.lower() == 'true':
+            # update script permission
+            st = os.stat(path)
+            os.chmod(path, st.st_mode | stat.S_IEXEC)
+            # execute the script
+            os.system(path)
     except:
         print >>sys.stderr, "Couldn't write file %s" % path
         sys.exit(1)


### PR DESCRIPTION
Added a new feature in CS to allow users or system admin to pass their user data scripts onto virtual machines then execute them. Users can specify their comma-separated user data scripts in VMUserData parameter in their JDL. They must be accessible via HTTP. Similarly, CS system admin can also specify user data script to run on all virtual machines created by CS using default_VMUserData parameter in cloud_scheduler.conf. These scripts specified in default_VMUserData must be local files. 
