### PR TITLE
Bugfix job defaults

### DIFF
--- a/cloud_scheduler.conf
+++ b/cloud_scheduler.conf
@@ -547,36 +547,36 @@ condor_collector_url: http://localhost:9618
 # default_VMType is the type of the VM - this type must match what is set
 #   in VMLoc or VMAMI image.
 #   the default value is 'default'
-#default_VMType= "default"
+#default_VMType= default
 
 #default_VMNetwork is the type of Nimbus network the VM will try to boot on
 #   common values are 'private' or 'public' blank means it will try to use any network
 #   this value is ignored for EC2 based VMs
 #
-#   the default value is ""
-#default_VMNetwork=""
+#   the default value is an empty string
+#default_VMNetwork=
 
 
 # default_VMCPUArch is the CPU Architecture the VM needs to use
 #   this can either be 'x86' or 'x86_64' for 32-bit or 64-bit VMs
 #
 #   the default value is "x86"
-#default_VMCPUArch= "x86"
+#default_VMCPUArch= x86
 
 # default_VMName is a name given to the VM for identifcation it can be any string
 #
 #   the default value is "Default-Image"
-#default_VMName= "Default-Image"
+#default_VMName= Default-Image
 
 # default_VMLoc specifys a URL to use for booting a VM on a Nimbus cloud
 #
-#   the default value is ""
-#default_VMLoc= ""
+#   the default value is an empty string
+#default_VMLoc= 
 
 # default_VMAMI specifies an AMI to boot an image on an EC2 service cloud (such as Amazon EC2)
 #
-#   the default value is ""
-#default_VMAMI= ""
+#   the default value is an empty string
+#default_VMAMI= 
 
 # default_VMMem specifies the amount of memory for a VM to use.
 #
@@ -595,8 +595,8 @@ condor_collector_url: http://localhost:9618
 
 # default_VMInstanceType specifies the EC2 instance type.
 #
-#   the default is ""
-#default_VMInstanceType= ""
+#   the default is an empty string
+#default_VMInstanceType=
 
 # default_VMMaximumPrice specifies the Maximum Price for Amazon spot pricing to use.
 #

--- a/cloudscheduler/job_management.py
+++ b/cloudscheduler/job_management.py
@@ -78,11 +78,9 @@ class Job:
     statuses = (SCHEDULED, UNSCHEDULED)
 
     def __init__(self, GlobalJobId="None", Owner="Default-User", JobPrio=1,
-             JobStatus=0, ClusterId=0, ProcId=0, VMType=config.default_VMType,
-             VMNetwork=config.default_VMNetwork, VMCPUArch=config.default_VMCPUArch, 
-             VMName=config.default_VMName, VMLoc=config.default_VMLoc, 
-             VMAMI={"default": config.default_VMAMI}, VMMem=config.default_VMMem, 
-             VMCPUCores=config.default_VMCPUCores, VMStorage=config.default_VMStorage, 
+             JobStatus=0, ClusterId=0, ProcId=0, VMType=None, VMNetwork=None,
+             VMCPUArch=None, VMName=None, VMLoc=None, VMAMI=None, VMMem=None,
+             VMCPUCores=None, VMStorage=None,
              VMKeepAlive=0, VMHighPriority=0, RemoteHost=None,
              CSMyProxyCredsName=None, CSMyProxyServer=None, CSMyProxyServerPort=None,
              x509userproxysubject=None, x509userproxy=None,
@@ -125,8 +123,26 @@ class Job:
                                 for when this can save you money (eg. with EC2)
 
      """
-        if VMType == "":
+
+        if not VMType:
             VMType = config.default_VMType
+        if not VMNetwork:
+            VMNetwork = config.default_VMNetwork
+        if not VMCPUArch:
+            VMCPUArch = config.default_VMCPUArch
+        if not VMName:
+            VMName = config.default_VMName
+        if not VMLoc:
+            VMLoc = config.default_VMLoc
+        if not VMAMI:
+            VMAMI = {"default": config.default_VMAMI}
+        if not VMMem:
+            VMMem = config.default_VMMem
+        if not VMCPUCores:
+            VMCPUCores = config.default_VMCPUCores
+        if not VMStorage:
+            VMStorage = config.default_VMStorage
+    
         self.id           = GlobalJobId
         self.user         = Owner
         self.uservmtype   = ':'.join([Owner, VMType])


### PR DESCRIPTION
- Fixed the issue that default job parameters defined in cloud_scheduler.conf were not passed to Job instances as no corresponding job parameters defined in users' JDL.
- Removed quotes in the job default values which may confuse sysadmin and prevent the configuration from running properly. 
