### PR TITLE
print the object type in an effort to debug #307

### DIFF
--- a/cloudscheduler/info_server.py
+++ b/cloudscheduler/info_server.py
@@ -378,7 +378,7 @@ class InfoServer(threading.Thread,):
 class VMJSONEncoder(json.JSONEncoder):
     def default(self, vm):
         if not isinstance (vm, VM):
-            log.error("Cannot use VMJSONEncoder on non VM object")
+            log.error("Cannot use VMJSONEncoder on non VM object of type %s" % type(vm))
             return
         return {'name': vm.name, 'id': vm.id, 'vmtype': vm.vmtype,
                 'hostname': vm.hostname, 'clusteraddr': vm.clusteraddr,


### PR DESCRIPTION
Add some additional output to understand what type of object is being passed to the json encoder when it's not a vm type. This should hopefully help to get more info for issue #307 .

@mhpx could you test this?
